### PR TITLE
fix: isRetry variable on retry requests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ export interface ISetupConfig {
 }
 
 type FetchFailureInfo = { text: string, code: number, response: unknown, isAbort: boolean, abortCode: number };
-type IFetchFailureHandle = (info: FetchFailureInfo, retry: () => Promise<any>) => any;
+type IFetchFailureHandle = (info: FetchFailureInfo, retry: (breakIfError?: boolean) => Promise<any>) => any;
 
 type SetupObject = ISetupConfig | ((item: Record<{}, {}, {}, {}, {}, {}>) => void)
 

--- a/ts/Record.ts
+++ b/ts/Record.ts
@@ -212,8 +212,7 @@ export default class Record {
         frozenKey: 0,                /** @deprecated [Nerd] :key variable, for manual watch effect */
 
         isError: false,
-        isLoading: false,
-        isRetry: false
+        isLoading: false
     })
 
     /** @deprecated [Nerd] Frozen Response for manual trigger WatchEffect */
@@ -1347,7 +1346,7 @@ export default class Record {
     /**
      * Call request
      */
-    private async doFetch(method: string = 'get') {
+    private async doFetch(method: string = 'get', isRetry?: boolean) {
         let launchTrace: string[] = [];
         if (configOptions.useTracing) {
             launchTrace = new Error().stack.split("at").slice(3);
@@ -1491,8 +1490,7 @@ export default class Record {
                 isAbort: this._abortController.isAborted(),
                 abortCode: this._abortController.getAbortCode(),
             }, (breakIfError?: boolean) => {
-                if (!breakIfError || !this._variables.isRetry) this.doFetch(method)
-                this._variables.isRetry = true
+                if (!breakIfError || !isRetry) this.doFetch(method, true)
             });
 
             // If answer had object data replace

--- a/ts/Record.ts
+++ b/ts/Record.ts
@@ -212,7 +212,8 @@ export default class Record {
         frozenKey: 0,                /** @deprecated [Nerd] :key variable, for manual watch effect */
 
         isError: false,
-        isLoading: false
+        isLoading: false,
+        isRetry: false
     })
 
     /** @deprecated [Nerd] Frozen Response for manual trigger WatchEffect */
@@ -1489,7 +1490,10 @@ export default class Record {
                 response: fetchResult.data,
                 isAbort: this._abortController.isAborted(),
                 abortCode: this._abortController.getAbortCode(),
-            }, () => this.doFetch(method));
+            }, () => {
+                if (!this._variables.isRetry) this.doFetch(method)
+                this._variables.isRetry = true
+            });
 
             // If answer had object data replace
             if (typeof answer == 'object') {

--- a/ts/Record.ts
+++ b/ts/Record.ts
@@ -1490,8 +1490,8 @@ export default class Record {
                 response: fetchResult.data,
                 isAbort: this._abortController.isAborted(),
                 abortCode: this._abortController.getAbortCode(),
-            }, () => {
-                if (!this._variables.isRetry) this.doFetch(method)
+            }, (breakIfError?: boolean) => {
+                if (!breakIfError || !this._variables.isRetry) this.doFetch(method)
                 this._variables.isRetry = true
             });
 


### PR DESCRIPTION
Кейс: используется глобальный обработчик ошибок запросов `onRequestFailure`.
В случае "зацикливания" ошибок на определённый запрос, возможно соответственно и зацикливание вызова функции `retry`().

Предлагаемое простое решение: завести переменную isRetry, которую ставить в true одновременно с вызовом функции retry. Далее retry вызывать только при `!isRetry` .

(осталось понять, какие подводные камни могут быть)