### PR TITLE
feat: runtime environment variables

### DIFF
--- a/nuxt/module.mjs
+++ b/nuxt/module.mjs
@@ -45,15 +45,6 @@ const module = defineNuxtModule({
     else
       _nuxt.options.vite.optimizeDeps.exclude.push('nuxoblivius', 'nuxoblivius-builds')
 
-    if (!_nuxt.options.routeRules)
-      _nuxt.options.routeRules = {}
-
-    for (const [rule, url] of Object.entries(_options.rules)) {
-      _nuxt.options.routeRules[rule + '/**'] = {
-        proxy: url + '/**'
-      }
-    }
-
     _nuxt.options.appConfig.nuxoblivius = {
       rules: _options.rules,
       logs: _options.logs,

--- a/nuxt/runtime/01.plugin.mjs
+++ b/nuxt/runtime/01.plugin.mjs
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, useAppConfig, useNuxtApp, useAsyncData } from "#app";
+import { defineNuxtPlugin, useAppConfig, useRuntimeConfig, useNuxtApp } from "#app";
 import { forgetAllStores } from "nuxoblivius/dist";
 import { RegisterTemplate } from "nuxoblivius";
 import { settings, options as configOptions } from "nuxoblivius/dist/config.js";
@@ -64,26 +64,23 @@ function printLogOnAny(...data) {
 }
 
 function getFetchUrl(url) {
-  let finalUrl = url;
-  let rule = "";
+  if (!appInfo.runOnServer) return url
 
-  if (appInfo.runOnServer) {
-    for (const [rulePattern, prefixUrl] of Object.entries(
-      appInfo.serverRewriteRules,
-    )) {
-      if (url.startsWith(rulePattern)) {
-        rule = rulePattern;
-        finalUrl = prefixUrl + url.slice(rulePattern.length);
-      }
+  for (const [rawPrefix, proxyUrl] of Object.entries(appInfo.serverRewriteRules)) {
+    const prefix = rawPrefix.startsWith('/') ? rawPrefix : `/${rawPrefix}`
+
+    if (url.startsWith(prefix)) {
+      const rest = url.slice(prefix.length)
+      return proxyUrl.replace(/\/$/, '') + '/' + rest.replace(/^\//, '')
     }
   }
 
-  return { url, finalUrl, rule };
+  return url
 }
 
 async function doRequest(uid, url, options, isBlob, abort) {
   const requestData = appInfo.nuxtRequests[uid];
-  let { finalUrl } = getFetchUrl(url);
+  let finalUrl = getFetchUrl(url);
 
   // If client and hydration return from cache:
   if (appInfo.useNuxtFetchWrapper && !appInfo.runOnServer) {
@@ -228,7 +225,7 @@ export default defineNuxtPlugin({
     let uid = nuxtApp.payload.nuxoblivius?.uid ?? generateUID();
     appInfo.isDev = true; // import.meta.dev;
 
-    const pluginConfig = useAppConfig().nuxoblivius;
+    const pluginConfig = useRuntimeConfig().public.nuxoblivius || useAppConfig().nuxoblivius || {};
 
     appInfo.isLogClientEnabled = !!pluginConfig.clientLogs;
     appInfo.isLogServerEnabled = !!pluginConfig.logs;


### PR DESCRIPTION
Немаловажная потребность для качественного production-а - возможность менять значения environment-переменных без пересборки Docker-контейнера (а лишь ограничиваясь перезапуском). К счастью, в Nuxt это осуществимо благодаря runtimeConfig.
Ранее routeRul-ы (для запросов state-менеджера) нужно было зашивать так:
```
export default defineNuxtConfig({
  nuxoblivius: {
    logs: true,
    rules: {
      '/api': process.env.API?.slice(0, -1), // Without / at end
      '/account': process.env.ACCOUNT?.slice(0, -1),
    },
  },
})
```
Теперь (после данного PR):
```
export default defineNuxtConfig({
  runtimeConfig: {
    public: {
      nuxoblivius: {
        rules: {
          api: '',
          account: '',
        },
        logs: true
      }
    }
  },
})
```
, что и позволит редактировать .env-ы без пересборки. Достаточно указывать в .env-файле значения с префиксом NUXT_PUBLIC.

Сохранена обратная совместимость (но бОльший приоритет при чтении nuxt.config-а даётся значениям runtimeConfig-а)

P.S. Подредачил бы под такое изменение и доку, если бы она не была в отдельном репозитории